### PR TITLE
Add vscode devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,32 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/typescript-node
+{
+  "name": "safety-check-app",
+  // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:1-20-bullseye",
+
+  // Features to add to the dev container. More info: https://containers.dev/features.
+  // "features": {},
+
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
+
+  // Use 'postCreateCommand' to run commands after the container is created.
+  "postCreateCommand": "npm install",
+
+  // Configure tool-specific properties.
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "angular.ng-template",
+        "nrwl.angular-console",
+        "esbenp.prettier-vscode",
+        "firsttris.vscode-jest-runner",
+        "dbaeumer.vscode-eslint"
+      ]
+    }
+  }
+
+  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  // "remoteUser": "root"
+}


### PR DESCRIPTION
Hello all!

In order to minimise dependencies installation, devcontainer configuration is added!
Only docker dependency needed :whale2: 

:point_right: [install docker on your system](https://docs.docker.com/engine/install/)
:point_right: open vscode and install [remote development extension](https://code.visualstudio.com/docs/devcontainers/containers) by typing `ext install ms-vscode-remote.vscode-remote-extensionpack` on the dialog when `ctrl + p` is clicked
:point_right: `ctrl + shift + p` + `Open folder in container` and open the clonned directory, where `.devcontainer` folder is present

`npm install` is executed automatically so:
:point_right: open a terminal inside vscode (menu terminal + new terminal)
:point_right: `npm start` and open web browser from vscode or go to [http://127.0.0.1:4200/sites](http://127.0.0.1:4200/sites)

Hope you find it useful :crossed_fingers: 